### PR TITLE
feat: Implement SHA-256 phase 1 step 1

### DIFF
--- a/src/Sha256/.gitkeep
+++ b/src/Sha256/.gitkeep
@@ -1,0 +1,1 @@
+# This file is intentionally left blank to ensure the directory is created.

--- a/src/Sha256/Internal.roc
+++ b/src/Sha256/Internal.roc
@@ -1,0 +1,61 @@
+interface Sha256.Internal exposes [] imports [Bitwise]
+
+h0 : U32
+h0 = 0x6a09e667
+
+h1 : U32
+h1 = 0xbb67ae85
+
+h2 : U32
+h2 = 0x3c6ef372
+
+h3 : U32
+h3 = 0xa54ff53a
+
+h4 : U32
+h4 = 0x510e527f
+
+h5 : U32
+h5 = 0x9b05688c
+
+h6 : U32
+h6 = 0x1f83d9ab
+
+h7 : U32
+h7 = 0x5be0cd19
+
+k : List U32
+k = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+]
+
+rotr : U32, U32 -> U32
+rotr = \n, x -> (x >> n) | (Bitwise.shiftLeftBy x (32 - n))
+
+shr : U32, U32 -> U32
+shr = \n, x -> x >> n
+
+ch : U32, U32, U32 -> U32
+ch = \x, y, z -> Bitwise.xor (Bitwise.and x y) (Bitwise.and (Bitwise.not x) z)
+
+maj : U32, U32, U32 -> U32
+maj = \x, y, z -> Bitwise.xor (Bitwise.xor (Bitwise.and x y) (Bitwise.and x z)) (Bitwise.and y z)
+
+bigSigma0 : U32 -> U32
+bigSigma0 = \x -> Bitwise.xor (Bitwise.xor (rotr 2 x) (rotr 13 x)) (rotr 22 x)
+
+bigSigma1 : U32 -> U32
+bigSigma1 = \x -> Bitwise.xor (Bitwise.xor (rotr 6 x) (rotr 11 x)) (rotr 25 x)
+
+smallSigma0 : U32 -> U32
+smallSigma0 = \x -> Bitwise.xor (Bitwise.xor (rotr 7 x) (rotr 18 x)) (shr 3 x)
+
+smallSigma1 : U32 -> U32
+smallSigma1 = \x -> Bitwise.xor (Bitwise.xor (rotr 17 x) (rotr 19 x)) (shr 10 x)


### PR DESCRIPTION
Defines initial constants and bitwise helper functions for SHA-256.

This commit introduces the foundational elements for the SHA-256 hashing algorithm within the `src/Sha256/Internal.roc` file.

Specifically, it includes:
- The eight initial hash values (H0-H7).
- The sixty-four round constants (K).
- The eight essential bitwise helper functions:
    - ROTR (rotr)
    - SHR (shr)
    - Ch (ch)
    - Maj (maj)
    - Big Sigma 0 (bigSigma0)
    - Big Sigma 1 (bigSigma1)
    - Small Sigma 0 (smallSigma0)
    - Small Sigma 1 (smallSigma1)

These components are defined as per the FIPS PUB 180-4 standard and will be used in subsequent steps to build the full SHA-256 implementation.