### PR TITLE
feat: Set up initial test file for SHA256 library

### DIFF
--- a/tests/TestSha256.roc
+++ b/tests/TestSha256.roc
@@ -1,0 +1,20 @@
+module TestSha256 exposes [main]
+
+imports [
+    roc/Test exposing [describe, test, expect, expectEq],
+    # Assuming Sha256 will be exposed by a package in the future,
+    # or that the build system handles relative paths appropriately.
+    # For now, this import path might need adjustment based on how
+    # the project is built/structured locally.
+    # Consider using a placeholder if direct relative import is problematic
+    # e.g. app "org.example.sha256" provides [Sha256] to "./app.roc"
+    # For a library, this might be handled by the package system.
+    # Using a relative path for now as a common starting point.
+    ../src/Sha256 exposing [Sha256] # Adjust if needed for actual Roc project structure
+]
+
+main =
+    describe "Sha256 Library Tests" [
+        test "Initial placeholder test" <| \{} ->
+            expectEq 1 1
+    ]


### PR DESCRIPTION
Creates the `tests` directory and `tests/TestSha256.roc`.

The new test file includes:
- Imports for Roc's Test module.
- An import for the main `Sha256` module (using a relative path `../src/Sha256` for now).
- A basic placeholder test suite structure to ensure the test runner can pick it up.

This corresponds to item 9 of Phase 3 in `phases.md`.