### PR TITLE
I've added tests for `bytesToHex` and removed the inline duplicates.

### DIFF
--- a/src/Sha256/Internal.roc
+++ b/src/Sha256/Internal.roc
@@ -348,17 +348,6 @@ runProcessChunkTests =
             expectU32Crash newState.h7 0x4009f386 "processChunk 'abc' H7'"
     {}
 
-runBytesToHexTests : {}
-runBytesToHexTests =
-    expectStrCrash (bytesToHex []) "" "bytesToHex []"
-    expectStrCrash (bytesToHex [0x00]) "00" "bytesToHex [0x00]"
-    expectStrCrash (bytesToHex [0x0A]) "0a" "bytesToHex [0x0A]"
-    expectStrCrash (bytesToHex [0xFF]) "ff" "bytesToHex [0xFF]"
-    expectStrCrash (bytesToHex [0xDE, 0xAD, 0xBE, 0xEF]) "deadbeef" "bytesToHex [0xDE, 0xAD, 0xBE, 0xEF]"
-    expectStrCrash (bytesToHex [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF]) "0123456789abcdef" "bytesToHex [0x01,...,0xEF]"
-    expectStrCrash (bytesToHex [0x0C, 0x0A, 0x0F, 0x0E]) "0c0a0f0e" "bytesToHex [0x0C, 0x0A, 0x0F, 0x0E]"
-    {}
-
 messageChunk_abc_bytes : List U8
 messageChunk_abc_bytes =
     [0x61, 0x62, 0x63, 0x80]
@@ -379,4 +368,3 @@ expected_schedule_abc_prefix =
 _ = runBitwiseHelperTests
 _ = runMessageScheduleTests
 _ = runProcessChunkTests
-_ = runBytesToHexTests

--- a/tests/TestSha256.roc
+++ b/tests/TestSha256.roc
@@ -1,20 +1,39 @@
 module TestSha256 exposes [main]
 
 imports [
-    roc/Test exposing [describe, test, expect, expectEq],
-    # Assuming Sha256 will be exposed by a package in the future,
-    # or that the build system handles relative paths appropriately.
-    # For now, this import path might need adjustment based on how
-    # the project is built/structured locally.
-    # Consider using a placeholder if direct relative import is problematic
-    # e.g. app "org.example.sha256" provides [Sha256] to "./app.roc"
-    # For a library, this might be handled by the package system.
-    # Using a relative path for now as a common starting point.
-    ../src/Sha256 exposing [Sha256] # Adjust if needed for actual Roc project structure
+    roc/Test exposing [describe, test, expectEq],
+    ../src/Sha256 exposing [Sha256],
+    ../src/Sha256/Internal exposing [bytesToHex]
 ]
 
 main =
     describe "Sha256 Library Tests" [
-        test "Initial placeholder test" <| \{} ->
-            expectEq 1 1
+        describe "bytesToHex Tests" [
+            test "empty list" <| \{} ->
+                expectEq (bytesToHex []) "",
+
+            test "single zero byte" <| \{} ->
+                expectEq (bytesToHex [0x00]) "00",
+
+            test "single byte with leading hex zero" <| \{} ->
+                expectEq (bytesToHex [0x0A]) "0a",
+
+            test "single byte max value" <| \{} ->
+                expectEq (bytesToHex [0xFF]) "ff",
+
+            test "four bytes 'deadbeef'" <| \{} ->
+                expectEq (bytesToHex [0xDE, 0xAD, 0xBE, 0xEF]) "deadbeef",
+
+            test "multiple bytes with leading hex zeros" <| \{} ->
+                expectEq (bytesToHex [0x01, 0x02, 0x03]) "010203",
+
+            test "eight bytes common sequence" <| \{} ->
+                expectEq (bytesToHex [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF]) "0123456789abcdef",
+
+            test "list of all zeros (4 bytes)" <| \{} ->
+                expectEq (bytesToHex [0x00, 0x00, 0x00, 0x00]) "00000000",
+
+            test "list of all 0xFF (4 bytes)" <| \{} ->
+                expectEq (bytesToHex [0xFF, 0xFF, 0xFF, 0xFF]) "ffffffff"
+        ]
     ]


### PR DESCRIPTION
Here's what I did:

- I added a dedicated test suite for `bytesToHex` in `tests/TestSha256.roc` using Roc's standard testing library. The test cases cover empty lists, single bytes (both with and without leading hex zeros), multi-byte sequences, all-zero sequences, and all-0xFF sequences.
- I modified `tests/TestSha256.roc` so it imports `bytesToHex` from `Sha256.Internal.roc`.
- I removed the old, redundant inline tests for `bytesToHex` (specifically, the `runBytesToHexTests` function and its call) from `src/Sha256/Internal.roc`. This helps to centralize the testing.