### PR TITLE
Add NIST byte vector tests for SHA-256

### DIFF
--- a/tests/TestSha256.roc
+++ b/tests/TestSha256.roc
@@ -3,7 +3,9 @@ module TestSha256 exposes [main]
 imports [
     roc/Test exposing [describe, test, expectEq],
     ../src/Sha256 exposing [Sha256],
-    ../src/Sha256/Internal exposing [bytesToHex]
+    ../src/Sha256/Internal exposing [bytesToHex],
+    roc/Str,
+    roc/List
 ]
 
 main =
@@ -55,5 +57,34 @@ main =
 
             test "64-byte string (padding test)" <| \{} ->
                 expectEq (Sha256.hashStr "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij") "f01c900c85153d4e5982365d03361031000fd5cca3c6624695012f1d6f2beb96"
+        ],
+
+        describe "hashToHex NIST Byte Vector Tests" [
+            test "empty byte list" <| \{} ->
+                expectEq (Sha256.hashToHex []) "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+
+            test "byte list for \"abc\"" <| \{} ->
+                expectEq (Sha256.hashToHex [0x61, 0x62, 0x63]) "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+
+            test "byte list for \"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq\"" <| \{} ->
+                expectEq (Sha256.hashToHex [
+                    0x61, 0x62, 0x63, 0x64, 0x62, 0x63, 0x64, 0x65, 0x63, 0x64, 0x65, 0x66,
+                    0x64, 0x65, 0x66, 0x67, 0x65, 0x66, 0x67, 0x68, 0x66, 0x67, 0x68, 0x69,
+                    0x67, 0x68, 0x69, 0x6A, 0x68, 0x69, 0x6A, 0x6B, 0x69, 0x6A, 0x6B, 0x6C,
+                    0x6A, 0x6B, 0x6C, 0x6D, 0x6B, 0x6C, 0x6D, 0x6E, 0x6C, 0x6D, 0x6E, 0x6F,
+                    0x6D, 0x6E, 0x6F, 0x70, 0x6E, 0x6F, 0x70, 0x71
+                ]) "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+
+            test "Million 'a's (RFC 6234 TEST3)" <| \{} ->
+                # Create a list of 1,000,000 'a' characters (0x61)
+                millionAs = List.repeat 0x61 1_000_000
+                expectEq (Sha256.hashToHex millionAs) "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
+
+            test "Exact block size message (RFC 6234 TEST4) - 64 bytes" <| \{} ->
+                # Input: "0123456701234567012345670123456701234567012345670123456701234567"
+                # Hex:   3031323334353637303132333435363730313233343536373031323334353637
+                #        3031323334353637303132333435363730313233343536373031323334353637
+                inputBytes = Str.toUtf8 "0123456701234567012345670123456701234567012345670123456701234567"
+                expectEq (Sha256.hashToHex inputBytes) "594847328451bdfa85056225462cc1d867d877fb388df0ce35f25ab5562bfbb5"
         ]
     ]


### PR DESCRIPTION
This commit implements item 12 of phase three from phases.md. It adds test cases to `tests/TestSha256.roc` using known NIST test vectors for byte array inputs.

The following test cases were added under a new describe block "hashToHex NIST Byte Vector Tests", using `Sha256.hashToHex`:

- Empty byte list
- "abc" as a byte list
- "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" (56 bytes)
- One million 'a' characters (1,000,000 bytes)
- "0123456701234567012345670123456701234567012345670123456701234567" (64 bytes, exact block size)

These tests ensure the core byte-level hashing is correct for various inputs, including those testing padding boundaries.