### PR TITLE
Add in-code documentation for Sha256 modules

### DIFF
--- a/src/Sha256.roc
+++ b/src/Sha256.roc
@@ -1,3 +1,21 @@
+##
+# The `Sha256` module provides functionalities for computing SHA-256 hashes.
+#
+# Purpose:
+# This module is designed to offer a straightforward way to generate SHA-256 hashes
+# for various types of input, adhering to the FIPS 180-4 standard.
+#
+# Inputs and Outputs:
+# The functions within this module primarily operate on `List U8` (list of bytes)
+# and `Str` (string) types. Outputs are generally `List U8` for raw hash bytes
+# or `Str` for hexadecimal string representations of hashes.
+#
+# Exposed Functions:
+# - `hash`: Computes the SHA-256 hash of a `List U8` and returns a `List U8`.
+# - `hashToHex`: Computes the SHA-256 hash of a `List U8` and returns a hexadecimal `Str`.
+# - `hashStrToHex`: Computes the SHA-256 hash of a `Str` and returns a hexadecimal `Str`.
+# - `hashStrToBytes`: Computes the SHA-256 hash of a `Str` and returns a `List U8`.
+##
 module Sha256 exposing [Sha256.{ hash, hashToHex, hashStrToHex, hashStrToBytes }]
 
 imports [
@@ -8,9 +26,21 @@ imports [
 
 # hash : List U8 -> List U8
 #
-# This is the core public hashing function. It takes a list of bytes (List U8)
-# as input and returns a 32-byte list (List U8) representing the
-# SHA-256 hash of the input.
+# Purpose:
+#   Computes the SHA-256 hash of a list of bytes.
+#
+# Parameters:
+#   - `inputBytes` : `List U8` - The list of bytes to hash.
+#
+# Return Value:
+#   - `List U8` - A 32-byte list representing the SHA-256 hash of `inputBytes`.
+#
+# Example:
+#   ```roc
+#   bytes : List U8 = [0x61, 0x62, 0x63] # "abc"
+#   hashedBytes : List U8 = Sha256.hash bytes
+#   # hashedBytes will be a 32-byte list representing the hash of "abc"
+#   ```
 hash : List U8 -> List U8
 hash = \inputBytes ->
     # Call the internal sha256Once function which performs the SHA-256 algorithm
@@ -18,9 +48,21 @@ hash = \inputBytes ->
 
 # hashToHex : List U8 -> Str
 #
-# This function takes a list of bytes (List U8) as input,
-# computes its SHA-256 hash, and then converts the resulting
-# hash bytes into a hexadecimal string representation.
+# Purpose:
+#   Computes the SHA-256 hash of a list of bytes and returns it as a hexadecimal string.
+#
+# Parameters:
+#   - `inputBytes` : `List U8` - The list of bytes to hash.
+#
+# Return Value:
+#   - `Str` - A string representing the hexadecimal encoding of the SHA-256 hash.
+#
+# Example:
+#   ```roc
+#   bytes : List U8 = [0x61, 0x62, 0x63] # "abc"
+#   hexStr : Str = Sha256.hashToHex bytes
+#   # hexStr will be "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+#   ```
 hashToHex : List U8 -> Str
 hashToHex = \inputBytes ->
     hashedBytes = hash inputBytes
@@ -28,9 +70,25 @@ hashToHex = \inputBytes ->
 
 # hashStrToHex : Str -> Str
 #
-# This function takes a string as input, converts it to a list of UTF-8 bytes,
-# computes its SHA-256 hash, and then converts the resulting hash bytes
-# into a hexadecimal string representation.
+# Purpose:
+#   Computes the SHA-256 hash of a string and returns it as a hexadecimal string.
+#
+# Parameters:
+#   - `inputStr` : `Str` - The string to hash.
+#
+# Return Value:
+#   - `Str` - A string representing the hexadecimal encoding of the SHA-256 hash.
+#
+# Assumptions:
+#   - The input string `inputStr` is assumed to be UTF-8 encoded.
+#     The function uses `Roc.Utf8.toBytes` for conversion.
+#
+# Example:
+#   ```roc
+#   text : Str = "hello world"
+#   hexHash : Str = Sha256.hashStrToHex text
+#   # hexHash will be "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+#   ```
 hashStrToHex : Str -> Str
 hashStrToHex = \inputStr ->
     inputBytes = Roc.Utf8.toBytes inputStr
@@ -38,8 +96,26 @@ hashStrToHex = \inputStr ->
 
 # hashStrToBytes : Str -> List U8
 #
-# This function takes a string as input, converts it to a list of UTF-8 bytes,
-# and then computes and returns its SHA-256 hash as a list of bytes.
+# Purpose:
+#   Computes the SHA-256 hash of a string and returns it as a list of bytes.
+#
+# Parameters:
+#   - `inputStr` : `Str` - The string to hash.
+#
+# Return Value:
+#   - `List U8` - A 32-byte list representing the SHA-256 hash of the UTF-8
+#     encoded `inputStr`.
+#
+# Assumptions:
+#   - The input string `inputStr` is assumed to be UTF-8 encoded.
+#     The function uses `Roc.Utf8.toBytes` for conversion.
+#
+# Example:
+#   ```roc
+#   text : Str = "Roc rocks!"
+#   byteHash : List U8 = Sha256.hashStrToBytes text
+#   # byteHash will be a 32-byte list representing the hash of "Roc rocks!"
+#   ```
 hashStrToBytes : Str -> List U8
 hashStrToBytes = \inputStr ->
     inputBytes = Roc.Utf8.toBytes inputStr


### PR DESCRIPTION
This commit adds comprehensive in-code documentation (Roc `##` comments) to the `Sha256` and `Sha256.Internal` modules.

Key changes:

- `src/Sha256.roc`:
    - Added module-level documentation explaining its purpose, adherence to FIPS 180-4, exposed functions, and I/O types.
    - Enhanced existing function-level comments for `hash`, `hashToHex`, `hashStrToHex`, and `hashStrToBytes` to include more details, assumptions (UTF-8 encoding), and simple usage examples.

- `src/Sha256/Internal.roc`:
    - Added module-level documentation clarifying its role for internal logic and its non-public API nature.
    - Documented constants: initial hash values (`h0`-`h7`) and round constants (`kConstants`), referencing FIPS 180-4.
    - Documented the `Sha256State` record.
    - Documented all helper functions (`rotr`, `shr`, `smallSigma0`, `smallSigma1`, `ch`, `maj`, `bigSigma0`, `bigSigma1`), including their purpose, parameters, return values, and FIPS 180-4 references.
    - Documented core logic functions (`padMessage`, `bytesToWordsBE`, `generateMessageSchedule`, `processChunk`, `sha256Once`, `u32sToBytes`, `bytesToHex`), detailing their purpose, parameters, return values, and relevant sections of the FIPS 180-4 standard.

These changes fulfill item 14 of Phase 4 ("Add In-Code Documentation") from the `phases.md` document.