### PR TITLE
feat: Add Package.roc for SHA-256 library

### DIFF
--- a/Package.roc
+++ b/Package.roc
@@ -1,0 +1,3 @@
+package "roc-community/sha256"
+    version "0.1.0"
+    exposes [Sha256]


### PR DESCRIPTION
This commit introduces the `Package.roc` file, which defines the metadata for the SHA-256 Roc library.

The package is named `roc-community/sha256` and its initial version is set to `0.1.0`. It exposes the `Sha256` module.

This addresses an item in my project plan.