### PR TITLE
Implement u32sToBytes function and add unit tests

### DIFF
--- a/src/Sha256/Internal.roc
+++ b/src/Sha256/Internal.roc
@@ -103,7 +103,16 @@ padMessage = \message ->
 ##
 ## Note: This is currently a placeholder and needs the actual conversion logic.
 u32sToBytes : List U32 -> List U8
-u32sToBytes = \_u32s -> List.repeat 0 32 # Actual conversion logic will be implemented later (expects 8 U32s, returns 32 U8s)
+u32sToBytes = \u32s ->
+    u32s
+        |> List.map \word ->
+            [
+                Num.toU8 (Bitwise.and (Bitwise.shiftRightBy word 24) 0xFF),
+                Num.toU8 (Bitwise.and (Bitwise.shiftRightBy word 16) 0xFF),
+                Num.toU8 (Bitwise.and (Bitwise.shiftRightBy word 8) 0xFF),
+                Num.toU8 (Bitwise.and word 0xFF),
+            ]
+        |> List.join
 
 ## bytesToHex : List U8 -> Str
 ##

--- a/tests/TestSha256.roc
+++ b/tests/TestSha256.roc
@@ -3,7 +3,7 @@ module TestSha256 exposes [main]
 imports [
     roc/Test exposing [describe, test, expectEq],
     ../src/Sha256 exposing [Sha256],
-    ../src/Sha256/Internal exposing [bytesToHex, padMessage], # Added padMessage
+    ../src/Sha256/Internal exposing [bytesToHex, padMessage, u32sToBytes], # Added u32sToBytes
     roc/Str,
     roc/List,
     roc/Num, # Added Num
@@ -180,5 +180,37 @@ main =
                 #        3031323334353637303132333435363730313233343536373031323334353637
                 inputBytes = Str.toUtf8 "0123456701234567012345670123456701234567012345670123456701234567"
                 expectEq (Sha256.hashToHex inputBytes) "594847328451bdfa85056225462cc1d867d877fb388df0ce35f25ab5562bfbb5"
-        ]
+        ],
+
+        u32sToBytesTests # Add the new test suite here
+    ]
+
+u32sToBytesTests =
+    describe "u32sToBytes Tests" [
+        test "empty list" <| \{} ->
+            expectEq (u32sToBytes []) ([] : List U8) "Empty list converts to empty list",
+
+        test "one U32" <| \{} ->
+            expectEq (u32sToBytes [0x01020304]) ([0x01, 0x02, 0x03, 0x04] : List U8) "Single U32",
+
+        test "multiple U32s" <| \{} ->
+            expectEq
+                (u32sToBytes [0x01020304, 0x05060708])
+                ([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08] : List U8)
+                "Multiple U32s",
+
+        test "U32 with leading zeros in bytes" <| \{} ->
+            expectEq (u32sToBytes [0x00112233]) ([0x00, 0x11, 0x22, 0x33] : List U8) "Leading zero bytes",
+
+        test "U32 with 0xFF bytes" <| \{} ->
+            expectEq (u32sToBytes [0xFFEEDDCC]) ([0xFF, 0xEE, 0xDD, 0xCC] : List U8) "0xFF bytes",
+
+        test "list of all zeros U32" <| \{} ->
+            expectEq
+                (u32sToBytes [0x00000000, 0x00000000])
+                ([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] : List U8)
+                "All zeros U32s",
+
+        test "list of all 0xFFFFFFFF U32" <| \{} ->
+            expectEq (u32sToBytes [0xFFFFFFFF]) ([0xFF, 0xFF, 0xFF, 0xFF] : List U8) "All 0xFFFFFFFF U32"
     ]


### PR DESCRIPTION
This commit introduces the `u32sToBytes` function in `src/Sha256/Internal.roc`. The function converts a `List U32` (expected to be the 8 final hash words) into a 32-byte `List U8` in big-endian order.

Each U32 word is converted to 4 bytes, with the most significant byte first:
- Byte 1: (word >> 24) & 0xFF
- Byte 2: (word >> 16) & 0xFF
- Byte 3: (word >> 8) & 0xFF
- Byte 4: word & 0xFF

Unit tests for `u32sToBytes` have been added to `tests/TestSha256.roc`. These tests cover various scenarios, including:
- Empty input list.
- Single and multiple U32 inputs.
- U32 values with leading zeros in bytes.
- U32 values with 0xFF bytes.
- Lists containing all-zero and all-one U32s.