### PR TITLE
Fix: Update test calls to use hashStrToHex for NIST vectors

### DIFF
--- a/tests/TestSha256.roc
+++ b/tests/TestSha256.roc
@@ -135,22 +135,22 @@ main =
 
         describe "hashStr NIST Vector Tests" [
             test "empty string" <| \{} ->
-                expectEq (Sha256.hashStr "") "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                expectEq (Sha256.hashStrToHex "") "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 
             test "\"abc\"" <| \{} ->
-                expectEq (Sha256.hashStr "abc") "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                expectEq (Sha256.hashStrToHex "abc") "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 
             test "55-byte string (padding test)" <| \{} ->
-                expectEq (Sha256.hashStr "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcde") "cf001c901192831856092573125f78092106111609845343c037a8c46d6a889c",
+                expectEq (Sha256.hashStrToHex "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcde") "cf001c901192831856092573125f78092106111609845343c037a8c46d6a889c",
 
             test "56-byte string (RFC 6234 TEST2_1)" <| \{} ->
-                expectEq (Sha256.hashStr "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq") "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
+                expectEq (Sha256.hashStrToHex "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq") "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
 
             test "63-byte string (padding test)" <| \{} ->
-                expectEq (Sha256.hashStr "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghi") "070f2a16846193990853e02a572a3c48d669e253781e0b848c97542de4e4e997",
+                expectEq (Sha256.hashStrToHex "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghi") "070f2a16846193990853e02a572a3c48d669e253781e0b848c97542de4e4e997",
 
             test "64-byte string (padding test)" <| \{} ->
-                expectEq (Sha256.hashStr "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij") "f01c900c85153d4e5982365d03361031000fd5cca3c6624695012f1d6f2beb96"
+                expectEq (Sha256.hashStrToHex "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij") "f01c900c85153d4e5982365d03361031000fd5cca3c6624695012f1d6f2beb96"
         ],
 
         describe "hashToHex NIST Byte Vector Tests" [


### PR DESCRIPTION
I corrected the function calls in the "hashStr NIST Vector Tests" within tests/TestSha256.roc.

Previously, these tests were calling Sha256.hashStr, which is not the public API function intended for returning hexadecimal string outputs. I've updated the tests to call Sha256.hashStrToHex, aligning them with the public API as specified in phase 2, item 1 of phases.md. This ensures the tests accurately validate the exposed hexadecimal string hashing functionality against NIST vectors.