### PR TITLE
I've reviewed and updated the in-code documentation for both `src/Sha…

### DIFF
--- a/src/Sha256.roc
+++ b/src/Sha256.roc
@@ -7,8 +7,8 @@
 #
 # Inputs and Outputs:
 # The functions within this module primarily operate on `List U8` (list of bytes)
-# and `Str` (string) types. Outputs are generally `List U8` for raw hash bytes
-# or `Str` for hexadecimal string representations of hashes.
+# and `Str` (string) types. Outputs are generally a 32-byte `List U8` for raw hash bytes
+# or a 64-character `Str` for hexadecimal string representations of hashes.
 #
 # Exposed Functions:
 # - `hash`: Computes the SHA-256 hash of a `List U8` and returns a `List U8`.

--- a/src/Sha256/Internal.roc
+++ b/src/Sha256/Internal.roc
@@ -15,7 +15,6 @@
 ##
 module Sha256.Internal exposing [rotr, shr, smallSigma0, smallSigma1, ch, maj, bigSigma0, bigSigma1, bytesToWordsBE, InvalidInput, generateMessageSchedule, processChunk, Sha256State, sha256Once, padMessage, u32sToBytes, bytesToHex]
 
-# Placeholder for padMessage
 ## padMessage : List U8 -> List U8
 ##
 ## Purpose:
@@ -33,8 +32,6 @@ module Sha256.Internal exposing [rotr, shr, smallSigma0, smallSigma1, ch, maj, b
 ##
 ## Return Value:
 ##   - `List U8` - The padded message, ready for processing in 512-bit (64-byte) chunks.
-##
-## Note: This is currently a placeholder and needs the actual padding logic.
 padMessage : List U8 -> List U8
 padMessage = \message ->
     originalLenBytes = List.len message
@@ -88,7 +85,6 @@ padMessage = \message ->
 
     List.concat paddedMsgWithZeros lenBytes
 
-# Placeholder for u32sToBytes
 ## u32sToBytes : List U32 -> List U8
 ##
 ## Purpose:
@@ -100,8 +96,6 @@ padMessage = \message ->
 ##
 ## Return Value:
 ##   - `List U8` - A 32-byte list representing the concatenated hash values.
-##
-## Note: This is currently a placeholder and needs the actual conversion logic.
 u32sToBytes : List U32 -> List U8
 u32sToBytes = \u32s ->
     u32s
@@ -229,6 +223,9 @@ generateMessageSchedule = \messageChunk ->
         finalSchedule = buildSchedule initialWords 16
         Ok finalSchedule
 
+## InvalidInput
+## Represents an error condition, typically for inputs that don't meet expected criteria,
+## e.g., a message chunk provided to `generateMessageSchedule` that is not 64 bytes long.
 InvalidInput : []
 
 ## rotr : U8, U32 -> U32


### PR DESCRIPTION
…256.roc` and `src/Sha256/Internal.roc`.

Here's a summary of what I did:
- Clarified the output length for hex strings in the `Sha256.roc` module documentation.
- Updated the comments for `padMessage` and `u32sToBytes` in `Sha256/Internal.roc` to remove their "placeholder" status.
- Added a descriptive comment for the `InvalidInput` type in `Sha256/Internal.roc`.
- Verified the accuracy, completeness, and clarity of existing comments for all public API functions, internal core logic functions, helper functions, and constants.
- Ensured that FIPS 180-4 standard references and algorithmic descriptions are accurate.