### PR TITLE
I've added an explicit comment above the crash site in the `sha256Onc…

### DIFF
--- a/src/Sha256/Internal.roc
+++ b/src/Sha256/Internal.roc
@@ -441,6 +441,7 @@ sha256Once = \message ->
                     Err InvalidInput ->
                         # This case should ideally not happen with correct padding
                         # For now, crash or return an error state; let's crash.
+                        # This crash should be unreachable if `padMessage` is implemented correctly, as `generateMessageSchedule` will only receive 64-byte chunks, thus `bytesToWordsBE` will not return `Err InvalidInput`.
                         crash "Invalid input to generateMessageSchedule during sha256Once"
 
     # 4. Convert final hash state (List U32) to List U8


### PR DESCRIPTION
…e` function in `src/Sha256/Internal.roc`.

The comment clarifies the invariant that the crash should be unreachable if `padMessage` is implemented correctly. This is because `generateMessageSchedule` will only receive 64-byte chunks, preventing `bytesToWordsBE` from returning `Err InvalidInput`.