### PR TITLE
I've reviewed and corrected the type annotations and docstrings for t…

### DIFF
--- a/src/Sha256/Internal.roc
+++ b/src/Sha256/Internal.roc
@@ -114,10 +114,10 @@ nibbleToHexChar : U8 -> U8
 nibbleToHexChar = \nibble ->
     if nibble < 10 then
         # 0-9
-        nibble + Char.toU8 '0'
+        nibble + 0x30 # ASCII '0'
     else
         # 10-15 (a-f)
-        (nibble - 10) + Char.toU8 'a'
+        (nibble - 10) + 0x61 # ASCII 'a'
 
 ## byteToHexChars : U8 -> { high : U8, low : U8 }
 ## Converts a U8 byte into a record of two U8 ASCII hex characters.


### PR DESCRIPTION
…he Sha256 modules.

I examined `src/Sha256.roc` and `src/Sha256/Internal.roc`.

- I ensured the type annotations are consistent with `rocdocs.txt`.
- I verified the clarity and accuracy of the docstrings.
- I corrected `nibbleToHexChar` in `src/Sha256/Internal.roc` to use U8 literals (0x30 for '0', 0x61 for 'a') instead of the non-standard `Char.toU8`.

All other type annotations and docstrings were found to be accurate and require no changes.