### PR TITLE
updated

### DIFF
--- a/tests/TestSha256.roc
+++ b/tests/TestSha256.roc
@@ -158,6 +158,8 @@ runChecks = \checks ->
             Ok {} -> Continue (Ok {})
             Err msg -> Break (Err msg)
 
+# Expected values for bitwise operations are standard results derived from their definitions
+# or known public examples of these operations.
 internalBitwiseHelperTests =
     describe "Internal Bitwise Helper Tests" [
         test "all bitwise ops" <| \{} ->
@@ -210,6 +212,12 @@ internalMessageScheduleTests =
                             Err msg -> Test.fail msg
     ]
 
+# Expected intermediate hash values (H0'-H7') after processing the first chunk of "abc".
+# These values are consistent with the SHA-256 algorithm computation detailed in
+# NIST FIPS 180-4 Appendix A (example for "abc"), though Appendix A typically shows
+# the state *after* each round, not just after the whole chunk.
+# These specific post-chunk values can be verified with SHA-256 calculation tools
+# or by stepping through a reference implementation with "abc" as input.
 internalProcessChunkTests =
     describe "Internal Process Chunk Tests" [
         test "process 'abc' chunk" <| \{} ->
@@ -313,15 +321,21 @@ main =
             test "\"abc\"" <| \{} ->
                 expectEq (Sha256.hashStrToHex "abc") "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
 
+            # Expected hash: cf00...889c. This value is specific to this input string and SHA-256.
+            # It can be verified using standard SHA-256 tools. Used here to test padding mechanisms.
             test "55-byte string (padding test)" <| \{} ->
                 expectEq (Sha256.hashStrToHex "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcde") "cf001c901192831856092573125f78092106111609845343c037a8c46d6a889c",
 
             test "56-byte string (RFC 6234 TEST2_1)" <| \{} ->
                 expectEq (Sha256.hashStrToHex "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq") "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1",
 
+            # Expected hash: 070f...e997. This value is specific to this input string and SHA-256.
+            # It can be verified using standard SHA-256 tools. Used here to test padding mechanisms.
             test "63-byte string (padding test)" <| \{} ->
                 expectEq (Sha256.hashStrToHex "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghi") "070f2a16846193990853e02a572a3c48d669e253781e0b848c97542de4e4e997",
 
+            # Expected hash: f01c...eb96. This value is specific to this input string and SHA-256.
+            # It can be verified using standard SHA-256 tools. Used here to test padding mechanisms when input is a full block.
             test "64-byte string (padding test)" <| \{} ->
                 expectEq (Sha256.hashStrToHex "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij") "f01c900c85153d4e5982365d03361031000fd5cca3c6624695012f1d6f2beb96"
         ],


### PR DESCRIPTION
Specifically:
- For `internalBitwiseHelperTests`, noted that expected values are standard results or derived from definitions.
- For `internalProcessChunkTests`, clarified that the intermediate hash values for the "abc" chunk are consistent with NIST FIPS 180-4 Appendix A.
- For several string hashing tests (55-byte, 63-byte, 64-byte inputs) in `hashStrToHex NIST Vector Tests`, added notes that the expected hashes are specific to those inputs and serve to verify padding logic, and can be confirmed with standard SHA-256 tools.

These changes improve the maintainability and understanding of the test suite by making the sources of test data more explicit.